### PR TITLE
Close .ini file after creating it to release the stream

### DIFF
--- a/FileSystemWatcher/FormMain.cs
+++ b/FileSystemWatcher/FormMain.cs
@@ -43,7 +43,7 @@ namespace deja_vu
         {
             if (!File.Exists(IniFileName))
             {
-                File.Create(IniFileName);
+                File.Create(IniFileName).Close();
             }
         }
 


### PR DESCRIPTION
Fixes a problem where first time the .ini file is created, it wasn't getting closed, so it failed to dispose of the stream properly and threw an exception.
