### PR TITLE
FifaLmao Corruption is not cool

### DIFF
--- a/src/Utilities/FileUtility.cs
+++ b/src/Utilities/FileUtility.cs
@@ -1,20 +1,15 @@
 ﻿using System;
-using System.CodeDom;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace deja_vu.Utilities
 {
     public static class FileUtility
     {
-        private const int FileBonusTime = 1000;
-
         public static void OnceDoneWriting(string path, Action<FileStream> action)
         {
             while (true)
@@ -24,9 +19,6 @@ namespace deja_vu.Utilities
                 {
                     using (var file = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
                     {
-                        //Give extra time for file to be completely written
-                        Thread.Sleep(FileBonusTime);
-
                         if (file.Length == 0)
                         {
                             throw new FileLoadException();

--- a/src/Utilities/FileUtility.cs
+++ b/src/Utilities/FileUtility.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.CodeDom;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -12,6 +13,7 @@ namespace deja_vu.Utilities
 {
     public static class FileUtility
     {
+        private const int FileBonusTime = 1000;
 
         public static void OnceDoneWriting(string path, Action<FileStream> action)
         {
@@ -22,9 +24,20 @@ namespace deja_vu.Utilities
                 {
                     using (var file = File.Open(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
                     {
+                        //Give extra time for file to be completely written
+                        Thread.Sleep(FileBonusTime);
+
+                        if (file.Length == 0)
+                        {
+                            throw new FileLoadException();
+                        }
                         action(file);
                     }
                     break;
+                }
+                catch (FileLoadException fex)
+                {
+                    Trace.TraceInformation("Invalid filesize. Waiting for filestream to close.");
                 }
                 catch (IOException ex)
                 {
@@ -34,7 +47,7 @@ namespace deja_vu.Utilities
                         throw;
                     }
                 }
-                Thread.Sleep(1000);
+                Thread.Sleep(600);
             }
         }
 


### PR DESCRIPTION
When writing replays while simultaneously writing a live stream buffer, the replay file had a size of zero because OBS started moving the buffer from RAM to disk, but not fast enough. This resulted in corruption when Deja-Vu would try to manipulate files. By a combination of checking the file stream size and waiting a predetermined amount of time, we can avoid that problem.

Closes https://github.com/The-Velvet-Room/deja-vu/issues/16
