### PR TITLE
Greatly reduce time sleeping so UI doesn't feel sluggish.

### DIFF
--- a/src/Utilities/FileUtility.cs
+++ b/src/Utilities/FileUtility.cs
@@ -39,7 +39,7 @@ namespace deja_vu.Utilities
                         throw;
                     }
                 }
-                Thread.Sleep(600);
+                Thread.Sleep(50);
             }
         }
 


### PR DESCRIPTION
We were sleeping for over half a second each time we detected that the file stream wasn't finished. This also must be completed before we show any visual updates, so it probably just felt worse than it really is. This lowers that time to make the UI "feel" a bit snappier now.
